### PR TITLE
update to net5.0 without rebasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
-This is a fork of [edge-js](https://github.com/agracio/edge-js) updating to netcoreapp3.0 for usage in upcoming [neo-one](https://github.com/neo-one-suite/neo-one) releases. Please see the fork documentation for more information.
-
+This is a fork of [edge-js](https://github.com/agracio/edge-js) updating to netcoreapp3.0, net5.0, and net6.0 for usage in upcoming [neo-one](https://github.com/neo-one-suite/neo-one) releases. Please see the fork documentation for more information.

--- a/binding.gyp
+++ b/binding.gyp
@@ -333,7 +333,7 @@
                         'lib/bootstrap/*.cs'
                       ],
                       'outputs': [
-                        'lib/bootstrap/bin/$(BUILDTYPE)/netcoreapp3.0/bootstrap.dll'
+                        'lib/bootstrap/bin/$(BUILDTYPE)/net5.0/bootstrap.dll'
                       ],
                       'action': [
                         'bash',

--- a/lib/bootstrap/bootstrap.csproj
+++ b/lib/bootstrap/bootstrap.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>bootstrap</AssemblyName>
     <PackageId>bootstrap</PackageId>

--- a/lib/edge.js
+++ b/lib/edge.js
@@ -49,8 +49,8 @@ if (edgeNative.match(/edge_coreclr\.node$/i)) {
     // how to compile literal C# at https://github.com/tjanczuk/edge-cs/blob/master/lib/edge-cs.js
     process.env.EDGE_USE_CORECLR = 1;
 }
-if (process.env.EDGE_USE_CORECLR && !process.env.EDGE_BOOTSTRAP_DIR && fs.existsSync(path.join(__dirname, 'bootstrap', 'bin', 'Release', 'netcoreapp3.0', 'bootstrap.dll'))) {
-    process.env.EDGE_BOOTSTRAP_DIR = path.join(__dirname, 'bootstrap', 'bin', 'Release', 'netcoreapp3.0');
+if (process.env.EDGE_USE_CORECLR && !process.env.EDGE_BOOTSTRAP_DIR && fs.existsSync(path.join(__dirname, 'bootstrap', 'bin', 'Release', 'net5.0', 'bootstrap.dll'))) {
+    process.env.EDGE_BOOTSTRAP_DIR = path.join(__dirname, 'bootstrap', 'bin', 'Release', 'net5.0');
 }
 
 process.env.EDGE_NATIVE = edgeNative;
@@ -119,7 +119,7 @@ exports.func = function(language, options) {
         }
 
         if (process.env.EDGE_USE_CORECLR) {
-            var defaultManifest = path.join(__dirname, 'bootstrap', 'bin', 'Release', 'netcoreapp3.0', 'bootstrap.deps.json');
+            var defaultManifest = path.join(__dirname, 'bootstrap', 'bin', 'Release', 'net5.0', 'bootstrap.deps.json');
             var compilerManifest;
             if(compiler.getBootstrapDependencyManifest){
                 compilerManifest = compiler.getBootstrapDependencyManifest();

--- a/package.json
+++ b/package.json
@@ -1,11 +1,7 @@
 {
   "name": "@neo-one/edge",
-  "author": {
-    "name": "Tomasz Janczuk <tomasz@janczuk.org>",
-    "url": "http://tomasz.janczuk.org",
-    "twitter": "tjanczuk"
-  },
-  "version": "15.0.0",
+  "author": "Spencer Corwin <spencer.corwin@neotracker.io>",
+  "version": "16.0.4",
   "description": "Edge.js: run .NET and Node.js in-process on Windows, Mac OS, and Linux",
   "tags": [
     "owin",
@@ -44,13 +40,13 @@
     "mocha": "5.1.1",
     "mocha-junit-reporter": "^1.17.0"
   },
-  "homepage": "https://github.com/agracio/edge-js",
+  "homepage": "https://github.com/neo-one-suite/edge",
   "repository": {
     "type": "git",
-    "url": "git@github.com:agracio/edge-js.git"
+    "url": "git@github.com:neo-one-suite/edge.git"
   },
   "bugs": {
-    "url": "http://github.com/agracio/edge-js/issues"
+    "url": "http://github.com/neo-one-suite/edge/issues"
   },
   "scripts": {
     "install": "node tools/install.js",

--- a/src/double/Edge.js.CSharp/Edge.js.CSharp.csproj
+++ b/src/double/Edge.js.CSharp/Edge.js.CSharp.csproj
@@ -3,7 +3,7 @@
     <Description>Edge.js enables scripting CLR languages from Node.js. This package is a dependency of Edge.js and supports scripting C# from Node.</Description>
     <AssemblyTitle>C# compiler for Edge.js</AssemblyTitle>
     <VersionPrefix>1.2.0</VersionPrefix>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <AssemblyName>Edge.js.CSharp</AssemblyName>
     <PackageId>Edge.js.CSharp</PackageId>
     <PackageProjectUrl>https://github.com/tjanczuk/edge</PackageProjectUrl>
@@ -11,6 +11,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
   </ItemGroup>
 </Project>

--- a/src/double/Edge.js/Edge.js.csproj
+++ b/src/double/Edge.js/Edge.js.csproj
@@ -3,11 +3,11 @@
     <Description>With Edge.js you can script Node.js in a .NET application. Edge.js allows you to run Node.js and .NET code in one process. You can call Node.js functions from .NET and .NET functions from Node.js. Edge.js takes care of marshalling data between CLR and V8. Edge.js also reconciles threading models of single threaded V8 and multi-threaded CLR. Edge.js ensures correct lifetime of objects on V8 and CLR heaps. This Edge.js NuGet package supports scripting Node.js v6.5.0.</Description>
     <Copyright>Copyright 2015 Tomasz Janczuk</Copyright>
     <VersionPrefix>9.3.0</VersionPrefix>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <AssemblyName>EdgeJs</AssemblyName>
     <PackageId>Edge.js</PackageId>
     <PackageTags>node.js;node;.net;edge;edge.js;v8;clr;coreclr;mono;interop;javascript</PackageTags>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/agracio/edge-js/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/neo-one-suite/edge/master/LICENSE</PackageLicenseUrl>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup>
@@ -61,7 +61,7 @@
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
   </ItemGroup>

--- a/src/double/Edge.js/dotnetcore/coreclrembedding.cs
+++ b/src/double/Edge.js/dotnetcore/coreclrembedding.cs
@@ -235,17 +235,17 @@ public class CoreCLREmbedding
                 AddDependencies(dependencyContext, RuntimeEnvironment.StandaloneApplication);
             }
 
-            string entryAssemblyPath = dependencyManifestFile.Replace(".deps.json", ".dll");
+            // string entryAssemblyPath = dependencyManifestFile.Replace(".deps.json", ".dll");
 
-            if (File.Exists(entryAssemblyPath))
-            {
-                Assembly entryAssembly = Assembly.Load(new AssemblyName(Path.GetFileNameWithoutExtension(entryAssemblyPath)));
-                Lazy<DependencyContext> defaultDependencyContext = new Lazy<DependencyContext>(() => DependencyContext.Load(entryAssembly));
+            // if (File.Exists(entryAssemblyPath))
+            // {
+            //     Assembly entryAssembly = Assembly.Load(new AssemblyName(Path.GetFileNameWithoutExtension(entryAssemblyPath)));
+            //     Lazy<DependencyContext> defaultDependencyContext = new Lazy<DependencyContext>(() => DependencyContext.Load(entryAssembly));
 
-                // I really don't like doing it this way, but it's the easiest way to give the running code access to the default 
-                // dependency context data
-                typeof(DependencyContext).GetField("_defaultContext", BindingFlags.Static | BindingFlags.NonPublic).SetValue(null, defaultDependencyContext);
-            }
+            //     // I really don't like doing it this way, but it's the easiest way to give the running code access to the default 
+            //     // dependency context data
+            //     typeof(DependencyContext).GetField("_defaultContext", BindingFlags.Static | BindingFlags.NonPublic).SetValue(null, defaultDependencyContext);
+            // }
 
             DebugMessage("EdgeAssemblyResolver::LoadDependencyManifest (CLR) - Finished");
         }
@@ -635,7 +635,7 @@ public class CoreCLREmbedding
 
             if (!Compilers.ContainsKey(compiler))
             {
-                if (!DependencyContext.Default.RuntimeLibraries.Any(l => l.Name == compiler))
+                if (DependencyContext.Default == null || !DependencyContext.Default.RuntimeLibraries.Any(l => l.Name == compiler))
                 {
                     if (!File.Exists(options["bootstrapDependencyManifest"].ToString()))
                     {

--- a/test/build.sh
+++ b/test/build.sh
@@ -4,7 +4,7 @@ if [ -n "$(which dotnet 2>/dev/null)" ]
 then
 	dotnet restore
 	dotnet build
-	cp bin/Debug/netcoreapp3.0/test.dll Edge.Tests.CoreClr.dll
+	cp bin/Debug/net5.0/test.dll Edge.Tests.CoreClr.dll
 fi
 
 if [ -n "$(which mono 2>/dev/null)" ]

--- a/test/test.bat
+++ b/test/test.bat
@@ -1,6 +1,6 @@
 rem usage: test.bat [ia32|x64 {version}], e.g. test.bat x64 0.10.0
 @echo off
-set EDGE_APP_ROOT=%~dp0\bin\Debug\netcoreapp3.0
+set EDGE_APP_ROOT=%~dp0\bin\Debug\net5.0
 set NODEEXE=node.exe
 set EDGE_USE_CORECLR=
 if "%1" neq "" if "%2" neq "" set NODEEXE=%~dp0\..\lib\native\win32\%1\%2\node.exe

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AssemblyName>test</AssemblyName>
@@ -33,11 +33,11 @@
     <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
 
   </ItemGroup>

--- a/tools/build_double_new.bat
+++ b/tools/build_double_new.bat
@@ -101,7 +101,7 @@ mkdir "%SELF%\build\nuget\lib"
 robocopy /NFL /NDL /NJH /NJS /nc /ns /np /is /s "%SELF%\..\src\double\Edge.js\bin\Release" "%SELF%\build\nuget\lib"
 rem robocopy /NFL /NDL /NJH /NJS /nc /ns /np /is /s "%SELF%\..\src\double\Edge.js\bin\Release\net40" "%SELF%\build\nuget\lib\net40"
 rem robocopy /NFL /NDL /NJH /NJS /nc /ns /np /is /s "%SELF%\..\src\double\Edge.js\bin\Release\net45" "%SELF%\build\nuget\lib\net45"
-rem robocopy /NFL /NDL /NJH /NJS /nc /ns /np /is /s "%SELF%\..\src\double\Edge.js\bin\Release\netcoreapp3.0" "%SELF%\build\nuget\lib\netcoreapp3.0"
+rem robocopy /NFL /NDL /NJH /NJS /nc /ns /np /is /s "%SELF%\..\src\double\Edge.js\bin\Release\net5.0" "%SELF%\build\nuget\lib\net5.0"
 rem robocopy /NFL /NDL /NJH /NJS /nc /ns /np /is /s "%SELF%\..\src\double\Edge.js\bin\Release\netcoreapp2.0" "%SELF%\build\nuget\lib\netcoreapp2.0"
 
 cd "%SELF%"
@@ -201,7 +201,7 @@ ROBOCOPY build/nuget/content/edge/x64 nuget/content/edge/x64 *.* /NFL /NDL /NJH 
 
 ROBOCOPY build/nuget/lib/net40 nuget/lib/net40 *.dll /NFL /NDL /NJH /NJS /nc /ns /np
 ROBOCOPY build/nuget/lib/net45 nuget/lib/net45 *.dll /NFL /NDL /NJH /NJS /nc /ns /np
-ROBOCOPY build/nuget/lib/netcoreapp3.0 nuget/lib/netcoreapp3.0 *.dll /NFL /NDL /NJH /NJS /nc /ns /np
+ROBOCOPY build/nuget/lib/net5.0 nuget/lib/net5.0 *.dll /NFL /NDL /NJH /NJS /nc /ns /np
 ROBOCOPY build/nuget/lib/netcoreapp2.0 nuget/lib/netcoreapp2.0 *.dll /NFL /NDL /NJH /NJS /nc /ns /np
 
 rem nuget pack

--- a/tools/coverage.js
+++ b/tools/coverage.js
@@ -47,7 +47,7 @@ function run(cmd, args, onClose, signal){
 
 function runOnSuccess(code, framework) {
     if (code === 0) {
-        process.env['EDGE_APP_ROOT'] = path.join(testDir, 'bin', 'Debug', 'netcoreapp3.0');
+        process.env['EDGE_APP_ROOT'] = path.join(testDir, 'bin', 'Debug', 'net5.0');
 
         createJunitReports(framework, false);
         createJunitReports(framework, true);

--- a/tools/test.js
+++ b/tools/test.js
@@ -20,7 +20,7 @@ else {
         if (code === 0) {
             run(process.platform === 'win32' ? 'dotnet.exe' : 'dotnet', ['build'], function(code, signal) {
                 if (code === 0) {
-                    run('cp', ['../test/bin/Debug/netcoreapp3.0/test.dll', '../test/Edge.Tests.CoreClr.dll'], runOnSuccess);
+                    run('cp', ['../test/bin/Debug/net5.0/test.dll', '../test/Edge.Tests.CoreClr.dll'], runOnSuccess);
                 }
             });
         }
@@ -53,7 +53,7 @@ function run(cmd, args, onClose){
 
 function runOnSuccess(code, signal) {
 	if (code === 0) {
-		process.env['EDGE_APP_ROOT'] = path.join(testDir, 'bin', 'Debug', 'netcoreapp3.0');
+		process.env['EDGE_APP_ROOT'] = path.join(testDir, 'bin', 'Debug', 'net5.0');
 		spawn('node', [mocha, testDir, '-R', 'spec', '-t', '10000', '-gc'], { 
 			stdio: 'inherit' 
 		}).on('error', function(err) {


### PR DESCRIPTION
- Updates our fork of the edge package to work with net5.0
- This work involved updating what Dan originally updated in the previous commits to get the package working with netcoreapp3.0. This package will need to be updated again for net6.0 and other future updates to C# .NET that is adopted by Neo and thus may be necessary for NEO•ONE.
- Some of the work in this commit came from looking at the latest work to the original edge-js repo, but I did NOT rebase our fork on top of their (the forked repo's) latest work. This might be something worth doing though.